### PR TITLE
FIR-9475: Using the cheapest instance

### DIFF
--- a/scripts/start_engine.py
+++ b/scripts/start_engine.py
@@ -4,6 +4,15 @@ from firebolt.common.settings import Settings
 from firebolt.service.manager import ResourceManager
 from firebolt.service.instance_type import HasStorage
 
+
+def get_cheapest_instance(rm: ResourceManager) -> str:
+    instance_list = rm.instance_types.instance_types
+    # Filter out instances without storage
+    instance_list = [i for i in instance_list if i.storage_size_bytes and i.storage_size_bytes != "0"]
+    cheapest = min(instance_list, key=lambda x: x.price_per_hour_cents)
+    return cheapest
+
+
 if __name__ == "__main__":
     rm = ResourceManager(Settings())
 
@@ -12,7 +21,7 @@ if __name__ == "__main__":
     database_name = argv[1]
     engine_name = database_name
     database = rm.databases.get_by_name(database_name)
-    instance_spec = rm.instance_types.get_cheapest(filters=[HasStorage])
+    instance_spec = get_cheapest_instance(rm).name
     engine = rm.engines.create(engine_name, scale=1, spec=instance_spec)
     engine.attach_to_database(database, True)
     engine.start()

--- a/scripts/start_engine.py
+++ b/scripts/start_engine.py
@@ -2,6 +2,7 @@ from sys import argv
 
 from firebolt.common.settings import Settings
 from firebolt.service.manager import ResourceManager
+from firebolt.service.instance_type import HasStorage
 
 if __name__ == "__main__":
     rm = ResourceManager(Settings())
@@ -11,13 +12,14 @@ if __name__ == "__main__":
     database_name = argv[1]
     engine_name = database_name
     database = rm.databases.get_by_name(database_name)
-    engine = rm.engines.create(engine_name, scale=1, spec="m5d.4xlarge")
+    instance_spec = rm.instance_types.get_cheapest(filters=[HasStorage])
+    engine = rm.engines.create(engine_name, scale=1, spec=instance_spec)
     engine.attach_to_database(database, True)
     engine.start()
 
     # No start needed, stopped engine should always be stopped
     stopped_engine_name = engine_name + "_stopped"
-    stopped_engine = rm.engines.create(stopped_engine_name, scale=1, spec="m5d.4xlarge")
+    stopped_engine = rm.engines.create(stopped_engine_name, scale=1, spec=instance_spec)
     stopped_engine.attach_to_database(database, True)
 
     print(engine.name, engine.endpoint, stopped_engine.name, stopped_engine.endpoint)


### PR DESCRIPTION
To not rely on hardcoded instance names we're using a dynamic way of fetching the instance type.

Tested by running start_engine.py script locally.