### PR TITLE
fix: Outputting db start error

### DIFF
--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -2870,7 +2870,7 @@ function start_db(python_dir, on_success, on_error) {
     [resolve_local_file('scripts/start_database.py'), core.getInput('db_suffix')],
     { env: fb_env }
   );
-  return result.error == null ? on_success(result.stdout.toString().trim('\n'), python_dir) : on_error(result.error.message);
+  return result.stderr.toString().length == 0 ? on_success(result.stdout.toString().trim('\n'), python_dir) : on_error(result.stderr.toString());
 }
 
 function start_engine(db_name, python_dir, on_success, on_error) {

--- a/setup.js
+++ b/setup.js
@@ -43,7 +43,7 @@ function start_db(python_dir, on_success, on_error) {
     [resolve_local_file('scripts/start_database.py'), core.getInput('db_suffix')],
     { env: fb_env }
   );
-  return result.error == null ? on_success(result.stdout.toString().trim('\n'), python_dir) : on_error(result.error.message);
+  return result.stderr.toString().length == 0 ? on_success(result.stdout.toString().trim('\n'), python_dir) : on_error(result.stderr.toString());
 }
 
 function start_engine(db_name, python_dir, on_success, on_error) {


### PR DESCRIPTION
`result.error` was always null so this function would succeed and we'd try to start an engine with empty string for a db. This fix should output the real error happening when provisioning the db.

Tested in a local run.