### PR TITLE
feat: Retry on rate limit after a backoff

### DIFF
--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -15379,6 +15379,8 @@ __nccwpck_require__.r(__webpack_exports__);
 const maxRetries = 3;
 // Delay between retries in milliseconds
 const backoffDelayMs = 1000; // 1 second
+// If we hit rate limit, wait for 60 seconds before retrying
+const backoffDelayRateLimit = 60000; // 60 seconds
 
 
 async function retryWithBackoff(fn) {
@@ -15391,6 +15393,10 @@ async function retryWithBackoff(fn) {
                 retryCount++;
                 console.log(`Received error 502. Retrying (${retryCount}/${maxRetries})...`);
                 await new Promise(resolve => setTimeout(resolve, backoffDelayMs));
+            } else if (error.statusCode === 429) {
+                retryCount++;
+                console.log(`Received error 429. Retrying (${retryCount}/${maxRetries})...`);
+                await new Promise(resolve => setTimeout(resolve, backoffDelayRateLimit));
             } else {
                 throw error;
             }

--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -15389,14 +15389,11 @@ async function retryWithBackoff(fn) {
         try {
             return await fn();
         } catch (error) {
-            if (error.statusCode === 502) {
+            if (error.statusCode === 502 || error.statusCode === 429) {
                 retryCount++;
-                console.log(`Received error 502. Retrying (${retryCount}/${maxRetries})...`);
-                await new Promise(resolve => setTimeout(resolve, backoffDelayMs));
-            } else if (error.statusCode === 429) {
-                retryCount++;
-                console.log(`Received error 429. Retrying (${retryCount}/${maxRetries})...`);
-                await new Promise(resolve => setTimeout(resolve, backoffDelayRateLimit));
+                console.log(`Received error ${error.statusCode}. Retrying (${retryCount}/${maxRetries})...`);
+                const delay = error.statusCode === 502 ? backoffDelayMs : backoffDelayRateLimit;
+                await new Promise(resolve => setTimeout(resolve, delay));
             } else {
                 throw error;
             }

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -15395,14 +15395,11 @@ async function retryWithBackoff(fn) {
         try {
             return await fn();
         } catch (error) {
-            if (error.statusCode === 502) {
+            if (error.statusCode === 502 || error.statusCode === 429) {
                 retryCount++;
-                console.log(`Received error 502. Retrying (${retryCount}/${maxRetries})...`);
-                await new Promise(resolve => setTimeout(resolve, backoffDelayMs));
-            } else if (error.statusCode === 429) {
-                retryCount++;
-                console.log(`Received error 429. Retrying (${retryCount}/${maxRetries})...`);
-                await new Promise(resolve => setTimeout(resolve, backoffDelayRateLimit));
+                console.log(`Received error ${error.statusCode}. Retrying (${retryCount}/${maxRetries})...`);
+                const delay = error.statusCode === 502 ? backoffDelayMs : backoffDelayRateLimit;
+                await new Promise(resolve => setTimeout(resolve, delay));
             } else {
                 throw error;
             }

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -15385,6 +15385,8 @@ __nccwpck_require__.r(__webpack_exports__);
 const maxRetries = 3;
 // Delay between retries in milliseconds
 const backoffDelayMs = 1000; // 1 second
+// If we hit rate limit, wait for 60 seconds before retrying
+const backoffDelayRateLimit = 60000; // 60 seconds
 
 
 async function retryWithBackoff(fn) {
@@ -15397,6 +15399,10 @@ async function retryWithBackoff(fn) {
                 retryCount++;
                 console.log(`Received error 502. Retrying (${retryCount}/${maxRetries})...`);
                 await new Promise(resolve => setTimeout(resolve, backoffDelayMs));
+            } else if (error.statusCode === 429) {
+                retryCount++;
+                console.log(`Received error 429. Retrying (${retryCount}/${maxRetries})...`);
+                await new Promise(resolve => setTimeout(resolve, backoffDelayRateLimit));
             } else {
                 throw error;
             }

--- a/util.js
+++ b/util.js
@@ -1,6 +1,8 @@
 const maxRetries = 3;
 // Delay between retries in milliseconds
 const backoffDelayMs = 1000; // 1 second
+// If we hit rate limit, wait for 60 seconds before retrying
+const backoffDelayRateLimit = 60000; // 60 seconds
 
 
 export async function retryWithBackoff(fn) {
@@ -13,6 +15,10 @@ export async function retryWithBackoff(fn) {
                 retryCount++;
                 console.log(`Received error 502. Retrying (${retryCount}/${maxRetries})...`);
                 await new Promise(resolve => setTimeout(resolve, backoffDelayMs));
+            } else if (error.statusCode === 429) {
+                retryCount++;
+                console.log(`Received error 429. Retrying (${retryCount}/${maxRetries})...`);
+                await new Promise(resolve => setTimeout(resolve, backoffDelayRateLimit));
             } else {
                 throw error;
             }

--- a/util.js
+++ b/util.js
@@ -11,14 +11,11 @@ export async function retryWithBackoff(fn) {
         try {
             return await fn();
         } catch (error) {
-            if (error.statusCode === 502) {
+            if (error.statusCode === 502 || error.statusCode === 429) {
                 retryCount++;
-                console.log(`Received error 502. Retrying (${retryCount}/${maxRetries})...`);
-                await new Promise(resolve => setTimeout(resolve, backoffDelayMs));
-            } else if (error.statusCode === 429) {
-                retryCount++;
-                console.log(`Received error 429. Retrying (${retryCount}/${maxRetries})...`);
-                await new Promise(resolve => setTimeout(resolve, backoffDelayRateLimit));
+                console.log(`Received error ${error.statusCode}. Retrying (${retryCount}/${maxRetries})...`);
+                const delay = error.statusCode === 502 ? backoffDelayMs : backoffDelayRateLimit;
+                await new Promise(resolve => setTimeout(resolve, delay));
             } else {
                 throw error;
             }


### PR DESCRIPTION
If we hit a rate limit on setup or destroy we should try to wait a min for when it resets and try again.

Seems to be [working](https://github.com/firebolt-db/firebolt-python-sdk/actions/runs/9694851857/job/26753385102), though we didn't encounter any 429.